### PR TITLE
NIPS23 update 

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,7 +513,7 @@ ContiFormer: Continuous-Time Transformer for Irregular Time Series Modeling
 
 Koopa: Learning Non-stationary Time Series Dynamics with Koopman Predictors
 
-Conformal Scorecasting: Anticipatory Uncertainty Quantification for Distribution Shift in Time Series
+Conformal PID Control for Time Series Prediction
 
 Drift doesn't Matter: Dynamic Decomposition with Diffusion Reconstruction for Unstable Multivariate Time Series Anomaly Detection
 

--- a/README.md
+++ b/README.md
@@ -501,8 +501,6 @@ Causal Discovery from Subsampled Time Series with Proxy Variables
 
 Predict, Refine, Synthesize: Self-Guiding Diffusion Models for Probabilistic Time Series Forecasting
 
-What if We Enrich day-ahead Solar Irradiance Time Series Forecasting with Spatio-Temporal Context?
-
 CrossGNN: Confronting Noisy Multivariate Time Series Via Cross Interaction Refinement
 
 Time Series Kernels based on Nonlinear Vector AutoRegressive Delay Embeddings


### PR DESCRIPTION
"What if We Enrich day-ahead Solar Irradiance Time Series Forecasting with Spatio-Temporal Context?" is not one papar in NIPS 2023, but one in ICML 2023 workshop

The name of paper "Conformal Scorecasting: Anticipatory Uncertainty Quantification for Distribution Shift in Time Series" should be "Conformal PID Control for Time Series Prediction"

"Sparse Graph Learning from Spatiotemporal Time Series" is one paper in JMLR but not in NIPS